### PR TITLE
How I got Windows working

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ When developing HyperHaskell itself, it is also possible to run it from source. 
 
 1. [Download and install Electron](http://electron.atom.io/releases/)
 
-    The whole thing is currently developed and tested with Electron v1.4.6.
+    The whole thing is currently developed and tested with Electron v1.4.8.
     
-    (If you use the [npm][] package manager, you can install with `npm install electron@1.4.6 -g`.
+    (If you use the [npm][] package manager, you can install with `npm install electron@1.4.8 -g`.
     On Debian-based Linux distributions, Electron [currently](https://github.com/electron-userland/electron-prebuilt/issues/70#issuecomment-192520913) requires the `nodejs-legacy` package.)
 
 2. Make sure that you have a working installation of

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ When developing HyperHaskell itself, it is also possible to run it from source. 
 
 1. [Download and install Electron](http://electron.atom.io/releases/)
 
-    The whole thing is currently developed and tested with Electron v1.4.0.
+    The whole thing is currently developed and tested with Electron v1.4.6.
     
-    (If you use the [npm][] package manager, you can install with `npm install electron@1.4.0 -g`.
+    (If you use the [npm][] package manager, you can install with `npm install electron@1.4.6 -g`.
     On Debian-based Linux distributions, Electron [currently](https://github.com/electron-userland/electron-prebuilt/issues/70#issuecomment-192520913) requires the `nodejs-legacy` package.)
 
 2. Make sure that you have a working installation of

--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ When developing HyperHaskell itself, it is also possible to run it from source. 
     
         ELECTRON=/usr/local/bin/electron
 
-    On Windows: ??
+    On Windows: You can locate `electron.exe` and double-click it. Then simply drop the `hyper-haskell\app` folder onto the lower pane of the window. Alternatively, from the terminal invoke what is suggested in the upper portion of the `Electron` window, i.e.
+    ``` shell
+    <path-to-electron>\electron.exe hyper-haskell\app
+    ```
 
 4. Go into the root directory of this repository and type `make run`.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Installation from the binary distribution follows the structure explained above.
 
         ![Settings](docs/screenshots/settings-back-end-cabal.png)
 
-        It is also possible to use [Stack][] by using `stack install`, but that is not fully explained here, only to some extend below.
+        It is also possible to use [Stack][] by using `stack install`, but that is not fully explained here, only to some extent below.
 
 That's it! Happy hyper!
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,7 +11,7 @@ Immediate
 
     * Implement a way to evaluate cells concurrently.
       We still want to be able to bind variables sequentially.
-      Using `forkIO` explicitely would do, but then we can't stop it again.
+      Using `forkIO` explicitly would do, but then we can't stop it again.
 
       Maybe a "suspended result"?
 

--- a/haskell/hyper/src/Hyper/Internal.hs
+++ b/haskell/hyper/src/Hyper/Internal.hs
@@ -36,7 +36,7 @@ string = Graphic . TL.toStrict . H.renderHtml . H.toHtml
 -- 
 -- NOTE: This function does not do check whether the input is well-formed HTML.
 --
--- NOTE: This function will probably deprecated once we figure out
+-- NOTE: This function will probably be deprecated once we figure out
 -- how to do this properly, but for now, just use it.
 html :: T.Text -> Graphic
 html = Graphic


### PR DESCRIPTION
Other things I observed:
-----

- I had to apply this patch
``` diff
index 155f443..2d97d3f 100644
--- a/app/src/interpreter.js
+++ b/app/src/interpreter.js
@@ -60,7 +60,8 @@ exports.main.init = () => {
       }
       args = ['--stack-yaml=' + packagePath, 'exec', '--', 'hyper-haskell-server']
     } else if (packageTool == 'cabal') {
-      cmd  = env['HOME'] + '/.cabal/bin/hyper-haskell-server'
+      cmd  = env['HOME'] + '\\AppData\\Roaming\\cabal\\bin\\hyper-haskell-server'
+cmd
     }
     
     // spawn process
```
- ~I still don't know how to start the interpreter reliably from `HyperHaskell`, for now I do it from another `cmd` console.~ It turns out I have no `stack` installed, and the `Settings` entry of my worksheet did not fall back to `cabal`. It works now when I manually set `cabal` without arguments.
- No `HyperHaskell` name set on the initial worksheet's name, I see "(untitled)" instead. It changes, though, upon loading of a worksheet.
- In the `cmd` console I cannot kill `hyper-haskell-server` by hitting ctrl-c.
- In *Windows* "Save" and "Save as" won't work.
- In *Windows*, when closing a worksheet, an exception happens.