### PR TITLE
Savefile now works cross-platform

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -186,7 +186,7 @@ BrowserWindow.prototype.getFilePath = function () {
 }
 
 BrowserWindow.prototype.saveFile = function () {
-  let path = this.getRepresentedFilename()
+  let path = this.getFilePath();
   if (path) {
     this.webContents.send('save-file', path)
     this.setDocumentEdited(false)

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -186,7 +186,7 @@ BrowserWindow.prototype.getFilePath = function () {
 }
 
 BrowserWindow.prototype.saveFile = function () {
-  let path = this.getFilePath();
+  let path = this.getFilePath()
   if (path) {
     this.webContents.send('save-file', path)
     this.setDocumentEdited(false)


### PR DESCRIPTION
BrowserWindow.getRepresentedFilename() is macOS specific according to https://github.com/facebook/nuclide/blob/master/flow-libs/electron.js.flow

this.getFilePath() should work cross-platform.