### PR TITLE
Add nix support

### DIFF
--- a/app/src/interpreter.js
+++ b/app/src/interpreter.js
@@ -32,7 +32,7 @@ exports.main.init = () => {
   const electron      = require('electron')
   ipc = electron.ipcMain
   app = electron.app
-  
+
   const appdir = require('path').dirname(app.getAppPath())
 
   // function that spawns a new interpreter process
@@ -52,6 +52,7 @@ exports.main.init = () => {
     env['PORT']  = port.toString()
     let cmd      = ''
     let args     = []
+
     if (packageTool == 'stack') {
       if (stackPath) {
         cmd = stackPath
@@ -61,8 +62,10 @@ exports.main.init = () => {
       args = ['--stack-yaml=' + packagePath, 'exec', '--', 'hyper-haskell-server']
     } else if (packageTool == 'cabal') {
       cmd  = env['HOME'] + '/.cabal/bin/hyper-haskell-server'
+    } else if (packageTool == 'nix') {
+      cmd = 'hyper-haskell-server'
     }
-    
+
     // spawn process
     let ghc = child_process.spawn(cmd, args, {
       cwd  : cwd,
@@ -123,7 +126,7 @@ exports.renderer.init = (window) => {
   const electron = require('electron')
   ipc            = electron.ipcRenderer
   remote         = electron.remote
-  
+
   ipc.on('interpreter-started', (event, port) => {
     down   = null
     myPort = port
@@ -185,7 +188,7 @@ const loadImports = (imports, newfiles, cont) => {
       })
     } else { importModules() }
   }
-  
+
   withLoadedFiles( () => {
     ajax({
       method : 'POST',
@@ -199,7 +202,7 @@ const loadImports = (imports, newfiles, cont) => {
 // Load modules, perhaps spawn a new process
 exports.renderer.loadImports = (config, cont) => {
   const doImports = () => { loadImports(config.imports, config.files, cont) }
-  
+
   if (   config.packagePath !== packagePath
       || config.packageTool !== packageTool
       || config.cwd         !== cwd) {

--- a/app/worksheet.html
+++ b/app/worksheet.html
@@ -28,6 +28,7 @@
         <select id="packageTool" size="1">
           <option value="cabal">cabal — (default paths) </option>
           <option value="stack">stack — stack.yaml</option>
+          <option value="nix">nix</option>
         </select>
         <input id="packagePath" type="text" value="">
       <p>

--- a/haskell/hyper-haskell-server.nix
+++ b/haskell/hyper-haskell-server.nix
@@ -1,0 +1,49 @@
+############################################################################
+# Nix derivation for the server back-end of the
+# HyperHaskell graphical Haskell interpreter.
+#
+# Install this file with:
+#   nix-env -if haskell/hyper-haskell-server.nix
+#
+# Then run the application with:
+#   nix-shell -p electron --run "electron app"
+#
+# Remember to set the Interpreter Back-end to "nix" in Settings,
+# and then Ctrl-R to Reload imports.
+#
+# Other haskell packages can be added to the environment by using the
+# --arg extra parameter of nix-env.
+#
+############################################################################
+
+{ pkgs ? import <nixpkgs> {}, extra ? ["hyper-extra"] }:
+
+let
+  executableHaskellDepends = ps: with ps; [
+      aeson base bytestring deepseq exceptions hint hyper scotty text
+      transformers
+    ] ++ (map (p: ps.${p}) extra);
+
+  ghc = pkgs.haskellPackages.ghcWithPackages executableHaskellDepends;
+
+  drv = ghc.haskellPackages.mkDerivation {
+    pname = "hyper-haskell-server";
+    version = "0.1.0.1";
+    sha256 = "43b0d770896ca0c38aee876bb23ee03b20009ce7afab4d6b5ca07a99f6e7f290";
+    isLibrary = false;
+    isExecutable = true;
+    executableHaskellDepends = executableHaskellDepends ghc.haskellPackages;
+    description = "Server back-end for the HyperHaskell graphical Haskell interpreter";
+    license = pkgs.stdenv.lib.licenses.bsd3;
+
+    buildTools = [ pkgs.makeWrapper ];
+    postInstall = ''
+      wrapProgram "$out/bin/hyper-haskell-server" \
+          --set NIX_GHC ${ghc}/bin/ghc \
+          --set NIX_GHCPKG ${ghc}/bin/ghc-pkg \
+          --set NIX_GHC_LIBDIR ${ghc}/lib/ghc-8.0.2
+    '';
+  };
+
+in
+  drv


### PR DESCRIPTION
Under nix one would build a hyper-haskell-server with the desired libraries and then install it into the environment.

This change adds an option for running the hyper-haskell-server which is on the PATH.

It also adds a file containing instructions on how to install the hyper-haskell-server with `nix-env`.
