### PR TITLE
Update hyper.cabal

### DIFF
--- a/haskell/hyper/hyper.cabal
+++ b/haskell/hyper/hyper.cabal
@@ -23,7 +23,7 @@ Source-repository head
 
 Library
     hs-source-dirs:     src
-    build-depends:      base         >= 4.6   && < 4.13
+    build-depends:      base         >= 4.5   && < 4.13
                         , deepseq    >= 1.2   && < 1.5
                         , blaze-html >= 0.7   && < 0.10
                         , text       >= 0.11  && < 1.3


### PR DESCRIPTION
allow base-4.5 for GHC-7.4.2
I have checked that it can be compiled.