### PR TITLE
Update hyper.cabal for GHC-9.8

### DIFF
--- a/haskell/hyper/hyper.cabal
+++ b/haskell/hyper/hyper.cabal
@@ -23,10 +23,10 @@ Source-repository head
 
 Library
     hs-source-dirs:     src
-    build-depends:      base         >= 4.5   && < 4.16
-                        , deepseq    >= 1.2   && < 1.5
+    build-depends:      base         >= 4.5   && < 4.20
+                        , deepseq    >= 1.2   && < 1.6
                         , blaze-html >= 0.7   && < 0.10
-                        , text       >= 0.11  && < 1.3
+                        , text       >= 0.11  && < 2.2
     exposed-modules:    Hyper
                         , Hyper.Internal
     default-language:   Haskell2010


### PR DESCRIPTION
relax version bounds for GHC-9.8
Could successfully compile with GHC-9.8.1.