### PR TITLE
Add experimental support for `cabal.project`

### DIFF
--- a/app/src/interpreter.js
+++ b/app/src/interpreter.js
@@ -90,6 +90,11 @@ exports.init = () => {
       } else {
         cmd  = env['HOME'] + '/.cabal/bin/hyper-haskell-server'
       }
+    } else if (packageTool == 'cabal.project') {
+      cmd = 'cabal'
+      // FIXME: Add cabal project dir that is relative to the current worksheet
+      // args = ['exec', '--project-dir', lib.path.dirname(packagePath), 'hyper-haskell-server']
+      args = ['exec', 'hyper-haskell-server']
     } else if (packageTool == 'nix') {
       cmd = 'hyper-haskell-server'
       env = Object.assign({}, lib.process.env, { PORT: port.toString() })

--- a/app/worksheet.html
+++ b/app/worksheet.html
@@ -32,6 +32,7 @@
         <label for="packagePath">Interpreter Back-end:</label>
         <select id="packageTool" size="1">
           <option value="cabal">cabal — (default paths) </option>
+          <option value="cabal.project">cabal — cabal.project</option>
           <option value="stack">stack — stack.yaml</option>
           <option value="nix">nix</option>
         </select>

--- a/worksheets/Test.hhs
+++ b/worksheets/Test.hhs
@@ -26,8 +26,8 @@
   "importModules": "import Main\nimport Hyper.Extra\nimport Test.QuickCheck",
   "loadFiles": "Test.hs",
   "settings": {
-    "packageTool": "stack",
-    "packagePath": "../haskell/stack.yaml",
-    "searchPath": "../worksheets"
+    "packageTool": "cabal.project",
+    "packagePath": "../",
+    "searchPath": "."
   }
 }


### PR DESCRIPTION
This pull request adds experimental support for pointing the interpreter backend to a `cabal.project` file. This feature is not robust yet, but I need it for testing.