### PR TITLE
Bump dependencies to newer GHC version

### DIFF
--- a/.github/workflows/build-haskell.yml
+++ b/.github/workflows/build-haskell.yml
@@ -33,11 +33,7 @@ jobs:
           - '9.6'
           - '9.8'
           - '9.10'
-        include:
-          - allow-failure: true
-            os: ubuntu-latest
-            cabal: '3.12'
-            ghc: '9.12'
+          - '9.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/haskell/hyper-extra/hyper-extra.cabal
+++ b/haskell/hyper-extra/hyper-extra.cabal
@@ -20,9 +20,10 @@ tested-with:
   , GHC == 8.10.7
   , GHC == 9.2.8
   , GHC == 9.4.7
-  , GHC == 9.6.6
+  , GHC == 9.6.7
   , GHC == 9.8.4
-  , GHC == 9.10.1
+  , GHC == 9.10.2
+  , GHC == 9.12.2
 
 source-repository head
   type:               git
@@ -34,8 +35,8 @@ library
   default-language:   Haskell2010
   build-depends:
     , base         >= 4.6     && < 4.22
-    , diagrams-lib >= 1.3     && < 1.5
-    , diagrams-svg >= 1.4     && < 1.5
+    , diagrams-lib >= 1.3     && < 1.6
+    , diagrams-svg >= 1.4     && < 1.6
     , hyper        >= 0.2     && < 0.3
     , QuickCheck   >= 2.3.0.2 && < 2.16
     , svg-builder  >= 0.1     && < 0.2

--- a/haskell/hyper-haskell-server/hyper-haskell-server.cabal
+++ b/haskell/hyper-haskell-server/hyper-haskell-server.cabal
@@ -19,9 +19,10 @@ tested-with:
   , GHC == 8.10.7
   , GHC == 9.2.8
   , GHC == 9.4.7
-  , GHC == 9.6.6
+  , GHC == 9.6.7
   , GHC == 9.8.4
   , GHC == 9.10.1
+  , GHC == 9.12.2
 
 source-repository head
   type:               git

--- a/haskell/hyper/hyper.cabal
+++ b/haskell/hyper/hyper.cabal
@@ -19,9 +19,10 @@ tested-with:
   , GHC == 8.10.7
   , GHC == 9.2.8
   , GHC == 9.4.7
-  , GHC == 9.6.6
+  , GHC == 9.6.7
   , GHC == 9.8.4
-  , GHC == 9.10.1
+  , GHC == 9.10.2
+  , GHC == 9.12.2
 
 source-repository head
   type:               git


### PR DESCRIPTION
This pull request performs the necessary dependency bumps to test against GHC 9.12.